### PR TITLE
LetsEncrypt TLS support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,7 @@ gitlab_package_detect_init: true
 
 # Attempt to modify kernel paramaters.
 gitlab_package_modify_kernel_parameters: true
+
+# To enable LetsEncrypt certificates, set the following variables
+# gitlab_letsencrypt_enable: true
+# gitlab_letsencrypt_email: webmaster@example.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,7 @@
     - { dest: /var/opt/gitlab/gitlab-rails/shared/registry, owner: registry, group: git }
     - { dest: /var/opt/gitlab/mattermost, owner: mattermost, group: mattermost }
     - { dest: /var/opt/gitlab/nginx, owner: root, group: gitlab-www, mode: "0750" }
-    - { dest: /var/opt/gitlab/nginx/www, owner: root, group: root, mode: "0750" }
+    - { dest: /var/opt/gitlab/nginx/www, owner: root, group: gitlab-www, mode: "0750" }
     - { dest: /var/opt/gitlab/postgresql, owner: gitlab-psql, group: gitlab-psql }
     - { dest: /var/opt/gitlab/prometheus, owner: gitlab-prometheus, group: gitlab-prometheus, mode: "0750" }
     - { dest: /var/opt/gitlab/redis, owner: gitlab-redis, group: git, mode: "0750" }

--- a/templates/etc/gitlab/gitlab.rb.j2
+++ b/templates/etc/gitlab/gitlab.rb.j2
@@ -2750,8 +2750,15 @@ node_exporter['enable'] = {{ gitlab_node_exporter_enable | bool | lower }}
 ################################################################################
 # Let's Encrypt integration
 ################################################################################
+{% if gitlab_letsencrypt_enable is defined and gitlab_letsencrypt_enable %}
+  letsencrypt['enable'] = true
+{% if gitlab_letsencrypt_email is defined %}
+  letsencrypt['contact_emails'] = ['{{ gitlab_letsencrypt_email }}']
+{% endif %}
+{% else %}
 # letsencrypt['enable'] = nil
 # letsencrypt['contact_emails'] = [] # This should be an array of email addresses to add as contacts
+{% endif %}
 # letsencrypt['group'] = 'root'
 # letsencrypt['key_size'] = 2048
 # letsencrypt['owner'] = 'root'


### PR DESCRIPTION
This is a template change and some additional variables documented in the defaults file to explain how to enable TLS certificates via LetsEncrypt. It uses GitLab's built-in certificate management to have a nice integration and go with what GitLab expects so things should work as smoothly as possible going forward (cert renewals, etc.).