### PR TITLE
Add ability to set initial root password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,7 @@ gitlab_package_detect_init: true
 
 # Attempt to modify kernel paramaters.
 gitlab_package_modify_kernel_parameters: true
+
+# To enable LetsEncrypt certificates, set the following variables
+# gitlab_letsencrypt_enable: true
+# gitlab_letsencrypt_email: webmaster@example.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,10 @@ gitlab_version: "{{ _gitlab_version }}"
 # GitLab external URL.
 gitlab_external_url: http://{{ ansible_facts['default_ipv4'].address }}
 
+# Optionally set the initial root password. If this is left undefined, GitLab will
+# generate a random password and write it to /etc/gitlab/initial_root_password
+# gitlab_initial_root_password: "PleaseUseAStrongPasswordHere"
+
 # Set to approximately 1/4 of available RAM.
 gitlab_postgresql_shared_buffers: 256MB
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,7 @@
     - { dest: /var/opt/gitlab/gitlab-rails/shared/registry, owner: registry, group: git }
     - { dest: /var/opt/gitlab/mattermost, owner: mattermost, group: mattermost }
     - { dest: /var/opt/gitlab/nginx, owner: root, group: gitlab-www, mode: "0750" }
-    - { dest: /var/opt/gitlab/nginx/www, owner: root, group: root, mode: "0750" }
+    - { dest: /var/opt/gitlab/nginx/www, owner: root, group: gitlab-www, mode: "0750" }
     - { dest: /var/opt/gitlab/postgresql, owner: gitlab-psql, group: gitlab-psql }
     - { dest: /var/opt/gitlab/prometheus, owner: gitlab-prometheus, group: gitlab-prometheus, mode: "0750" }
     - { dest: /var/opt/gitlab/redis, owner: gitlab-redis, group: git, mode: "0750" }

--- a/templates/etc/gitlab/gitlab.rb.j2
+++ b/templates/etc/gitlab/gitlab.rb.j2
@@ -2750,8 +2750,15 @@ node_exporter['enable'] = {{ gitlab_node_exporter_enable | bool | lower }}
 ################################################################################
 # Let's Encrypt integration
 ################################################################################
+{% if gitlab_letsencrypt_enable is defined and gitlab_letsencrypt_enable %}
+  letsencrypt['enable'] = true
+{% if gitlab_letsencrypt_email is defined %}
+  letsencrypt['contact_emails'] = ['{{ gitlab_letsencrypt_email }}']
+{% endif %}
+{% else %}
 # letsencrypt['enable'] = nil
 # letsencrypt['contact_emails'] = [] # This should be an array of email addresses to add as contacts
+{% endif %}
 # letsencrypt['group'] = 'root'
 # letsencrypt['key_size'] = 2048
 # letsencrypt['owner'] = 'root'

--- a/templates/etc/gitlab/gitlab.rb.j2
+++ b/templates/etc/gitlab/gitlab.rb.j2
@@ -712,7 +712,11 @@ external_url '{{ gitlab_external_url }}'
 #### Change the initial default admin password and shared runner registration tokens.
 ####! **Only applicable on initial setup, changing these settings after database
 ####!   is created and seeded won't yield any change.**
+{% if gitlab_initial_root_password is defined %}
+  gitlab_rails['initial_root_password'] = "{{ gitlab_initial_root_password }}"
+{% else %}
 # gitlab_rails['initial_root_password'] = "password"
+{% endif %}
 # gitlab_rails['initial_shared_runners_registration_token'] = "token"
 
 #### Toggle if root password should be printed to STDOUT during initialization


### PR DESCRIPTION
This not only give the option to set a root password, but it also documents the default behavior (both before and after this PR) of how a random password is generated and where the admin can find it on the server.